### PR TITLE
Update commandParser.js

### DIFF
--- a/middleware/commandParser.js
+++ b/middleware/commandParser.js
@@ -9,7 +9,7 @@ const commandParser = async (message, next, wiggle) => {
 
 	message.originalContent = message.content;
 	let match = message.content.match(prefixRegex);
-	if(!match && message.channel.guild) return;
+	if(!match && message.channel.guild) return next();
 	else if(match) [, message.content] = match;
 
 	let command;


### PR DESCRIPTION
CommandParser will now return next middleware properly if no prefix was found